### PR TITLE
Use a single, templated Dockerfile for the dashboard service

### DIFF
--- a/dashboard/Dockerfile.raspberrypi4-64
+++ b/dashboard/Dockerfile.raspberrypi4-64
@@ -1,6 +1,0 @@
-FROM balenablocks/dashboard:aarch64-1.1.4
-
-COPY ./geth.json /usr/share/grafana/conf/provisioning/dashboards
-COPY ./disk-usage.json /usr/share/grafana/conf/provisioning/dashboards
-COPY ./dashboards.yml /usr/share/grafana/conf/provisioning/dashboards
-COPY ./prometheus-datasource.yml /usr/share/grafana/conf/provisioning/datasources

--- a/dashboard/Dockerfile.template
+++ b/dashboard/Dockerfile.template
@@ -1,4 +1,4 @@
-FROM balenablocks/dashboard:amd64-1.1.4
+FROM balenablocks/dashboard:%%BALENA_ARCH%%-1.1.4
 
 COPY ./geth.json /usr/share/grafana/conf/provisioning/dashboards
 COPY ./disk-usage.json /usr/share/grafana/conf/provisioning/dashboards


### PR DESCRIPTION
# Description

I think we can use a single Dockerfile template and the `%%BALENA_ARCH%%` variable to adjust to each platform. And as a result, avoid copy pasting the contents of the file.

# Test plan

Deployed it to my Raspberry Pi 4 and things worked:

```
➜  balena-ethereum-node git:(master) ✗ balena push crypto
--------------------------------------------------------------------------------
[Warn] Node.js version "14.19.1" does not satisfy requirement ">=12.8.0 <13.0.0"
[Warn] This may cause unexpected behavior.
--------------------------------------------------------------------------------
[Info]        Starting build for crypto, user konrad1
[Info]        Dashboard link: https://dashboard.balena-cloud.com/apps/1925288/devices
[Info]        Building on arm01
[geth]        Step 1/10 : FROM ethereum/client-go:v1.10.15 as client-go
[prometheus]  Step 1/6 : FROM balenalib/raspberrypi4-64-alpine:3.14
[dashboard]   Step 1/5 : FROM balenablocks/dashboard:aarch64-1.1.4
[geth]         ---> c55e84b1b3a5
[geth]        Step 2/10 : FROM balenalib/raspberrypi4-64-alpine:3.14
[dashboard]    ---> c6407725aa4e
[dashboard]   Step 2/5 : COPY ./geth.json /usr/share/grafana/conf/provisioning/dashboards
[dashboard]    ---> 02d85cd7981e
[dashboard]   Step 3/5 : COPY ./disk-usage.json /usr/share/grafana/conf/provisioning/dashboards
[geth]         ---> b9be39de109b
[geth]        Step 3/10 : WORKDIR /app
[prometheus]   ---> b9be39de109b
[prometheus]  Step 2/6 : WORKDIR /app
[geth]         ---> Running in be03919b67c7
[prometheus]   ---> Running in 31998fc7b80d
[dashboard]    ---> 3074e895675c
[dashboard]   Step 4/5 : COPY ./dashboards.yml /usr/share/grafana/conf/provisioning/dashboards
[prometheus]  Removing intermediate container 31998fc7b80d
[prometheus]   ---> fcd2d7b3de74
[prometheus]  Step 3/6 : RUN install_packages prometheus
[prometheus]   ---> Running in 3d8eec81a0ee
[geth]        Removing intermediate container be03919b67c7
[geth]         ---> 6eb11475e146
[geth]        Step 4/10 : EXPOSE 8545 8546 30303 30303/udp
[geth]         ---> Running in 1f3220f40e66
[dashboard]    ---> 7253a4816bf7
[dashboard]   Step 5/5 : COPY ./prometheus-datasource.yml /usr/share/grafana/conf/provisioning/datasources
[geth]        Removing intermediate container 1f3220f40e66
[geth]         ---> 4f79f0e88801
[geth]        Step 5/10 : ENV UDEV=on
[geth]         ---> Running in 8815a403afbe
[prometheus]  Here are a few details about this Docker image (For more information please visit https://www.balena.io/docs/reference/base-images/base-images/): 
[prometheus]  Architecture: ARM v8 
[prometheus]  OS: Alpine Linux 3.14 
[prometheus]  Variant: run variant 
[prometheus]  Default variable(s): UDEV=off 
[prometheus]  Extra features: 
[prometheus]  - Easy way to install packages with `install_packages <package-name>` command 
[prometheus]  - Run anywhere with cross-build feature  (for ARM only) 
[prometheus]  - Keep the container idling with `balena-idle` command 
[prometheus]  - Show base image details with `balena-info` command
[prometheus]  fetch https://dl-cdn.alpinelinux.org/alpine/v3.14/main/aarch64/APKINDEX.tar.gz
[prometheus]  fetch https://dl-cdn.alpinelinux.org/alpine/v3.14/community/aarch64/APKINDEX.tar.gz
[prometheus]  (1/1) Installing prometheus (2.27.1-r3)
[prometheus]  Executing prometheus-2.27.1-r3.pre-install
[prometheus]  Executing busybox-1.33.1-r6.trigger
[prometheus]  OK: 231 MiB in 80 packages
[geth]        Removing intermediate container 8815a403afbe
[geth]         ---> 12b21cfc2738
[geth]        Step 6/10 : RUN install_packages lsblk jq parted e2fsprogs e2fsprogs-extra hdparm prometheus-node-exporter
[geth]         ---> Running in 33e5b12086ad
[dashboard]    ---> a7bc3b063728
[dashboard]   Successfully built a7bc3b063728
[prometheus]  Removing intermediate container 3d8eec81a0ee
[prometheus]   ---> 313916ff3aab
[prometheus]  Step 4/6 : COPY prometheus.yml /etc/prometheus/prometheus.yml
[geth]        Here are a few details about this Docker image (For more information please visit https://www.balena.io/docs/reference/base-images/base-images/): 
[geth]        Architecture: ARM v8 
[geth]        OS: Alpine Linux 3.14 
[geth]        Variant: run variant 
[geth]        Default variable(s): UDEV=off 
[geth]        Extra features: 
[geth]        - Easy way to install packages with `install_packages <package-name>` command 
[geth]        - Run anywhere with cross-build feature  (for ARM only) 
[geth]        - Keep the container idling with `balena-idle` command 
[geth]        - Show base image details with `balena-info` command
[geth]        fetch https://dl-cdn.alpinelinux.org/alpine/v3.14/main/aarch64/APKINDEX.tar.gz
[geth]        fetch https://dl-cdn.alpinelinux.org/alpine/v3.14/community/aarch64/APKINDEX.tar.gz
[geth]        (1/13) Installing libcom_err (1.46.2-r0)
[geth]        (2/13) Installing e2fsprogs-libs (1.46.2-r0)
[geth]        (3/13) Installing libuuid (2.37.4-r0)
[geth]        (4/13) Installing e2fsprogs (1.46.2-r0)
[geth]        (5/13) Installing e2fsprogs-extra (1.46.2-r0)
[geth]        (6/13) Installing hdparm (9.62-r0)
[geth]        (7/13) Installing oniguruma (6.9.7.1-r0)
[geth]        (8/13) Installing jq (1.6-r1)
[geth]        (9/13) Installing libsmartcols (2.37.4-r0)
[geth]        (10/13) Installing lsblk (2.37.4-r0)
[geth]        (11/13) Installing device-mapper-libs (2.02.187-r1)
[geth]        (12/13) Installing parted (3.4-r0)
[geth]        (13/13) Installing prometheus-node-exporter (1.1.2-r3)
[geth]        Executing prometheus-node-exporter-1.1.2-r3.pre-install
[geth]        Executing busybox-1.33.1-r6.trigger
[geth]        OK: 94 MiB in 92 packages
[prometheus]   ---> 19e91b9e4b73
[prometheus]  Step 5/6 : COPY start.sh .
[geth]        Removing intermediate container 33e5b12086ad
[geth]         ---> 03ff0d95bdaf
[geth]        Step 7/10 : COPY --from=client-go /usr/local/bin/geth /usr/local/bin/
[prometheus]   ---> 6bbea2ff57b4
[prometheus]  Step 6/6 : CMD [ "/bin/bash", "/app/start.sh" ]
[prometheus]   ---> Running in c7b88c02fb38
[prometheus]  Removing intermediate container c7b88c02fb38
[prometheus]   ---> da8aacdf3547
[prometheus]  Successfully built da8aacdf3547
[geth]         ---> a6641d656777
[geth]        Step 8/10 : COPY scripts scripts
[geth]         ---> d48453c87d6c
[geth]        Step 9/10 : ENTRYPOINT [ "/bin/bash", "/app/scripts/entry.sh" ]
[geth]         ---> Running in bd6be8c842ab
[geth]        Removing intermediate container bd6be8c842ab
[geth]         ---> 7fc322449343
[geth]        Step 10/10 : CMD [ "geth" ]
[geth]         ---> Running in 9d6dfd3a8280
[geth]        Removing intermediate container 9d6dfd3a8280
[geth]         ---> 73dbdde43057
[geth]        Successfully built 73dbdde43057
[influxdb]    [=========================================================] 100%
[Info]        Uploading images
[Success]     Successfully uploaded images
[Info]        Built on arm01
[Success]     Release successfully created!
[Info]        Release: d459b2441fe2825dfb8aa4e26e7c8e08 (id: 2142995)
[Info]        ┌────────────┬────────────┬──────────────────────┐
[Info]        │ Service    │ Image Size │ Build Time           │
[Info]        ├────────────┼────────────┼──────────────────────┤
[Info]        │ geth       │ 140.46 MB  │ 1 minute, 43 seconds │
[Info]        ├────────────┼────────────┼──────────────────────┤
[Info]        │ influxdb   │ 276.63 MB  │ 1 minute, 1 second   │
[Info]        ├────────────┼────────────┼──────────────────────┤
[Info]        │ dashboard  │ 223.98 MB  │ 1 minute, 12 seconds │
[Info]        ├────────────┼────────────┼──────────────────────┤
[Info]        │ prometheus │ 236.21 MB  │ 1 minute, 30 seconds │
[Info]        ├────────────┼────────────┼──────────────────────┤
[Info]        │ hostname   │ 6.57 MB    │ 8 seconds            │
[Info]        └────────────┴────────────┴──────────────────────┘
[Info]        Build finished in 2 minutes, 54 seconds
                            \
                             \
                              \\
                               \\
                                >\/7
                            _.-(6'  \
                           (=___._/` \
                                )  \ |
                               /   / |
                              /    > /
                             j    < _\
                         _.-' :      ``.
                         \ r=._\        `.
                        <`\\_  \         .`-.
                         \ r-7  `-. ._  ' .  `\
                          \`,      `-.`7  7)   )
                           \/         \|  \'  / `-._
                                      ||    .'
                                       \\  (
                                        >\  >
                                    ,.-' >.'
                                   <.'_.''
                                     <'
➜  balena-ethereum-node git:(master) ✗ 
```