### PR TITLE
Bump patch version of ethereum/client-go to 1.10.17

### DIFF
--- a/geth/Dockerfile.template
+++ b/geth/Dockerfile.template
@@ -1,4 +1,4 @@
-FROM ethereum/client-go:v1.10.15 as client-go
+FROM ethereum/client-go:v1.10.17 as client-go
 
 FROM balenalib/%%BALENA_MACHINE_NAME%%-alpine:3.14
 


### PR DESCRIPTION
Hey @tmigone !

I'm about to start running this and I figured it won't hurt to bump the patch version beforehand.

Can you think of any reason why this could be risky? Shall I test it beforehand?

I think normally bumping patch version should be harmless, but let me know please!